### PR TITLE
Add enable_service flag to nimbus config

### DIFF
--- a/manifests/drpc.pp
+++ b/manifests/drpc.pp
@@ -39,10 +39,11 @@ class storm::drpc(
 
   # Install drpc /etc/default
   storm::service { 'drpc':
-    start      => 'yes',
-    enable     => $enable,
-    jvm_memory => $mem,
-    opts       => $jvm,
+    start       => 'yes',
+    config_file => $config_file,
+    enable      => $enable,
+    jvm_memory  => $mem,
+    opts        => $jvm,
   }
 
 }

--- a/manifests/mesos.pp
+++ b/manifests/mesos.pp
@@ -36,11 +36,12 @@ class storm::mesos(
 
   # Install ui /etc/default
   storm::service { 'mesos':
-    start      => 'yes',
-    enable     => $enable,
-    jvm_memory => $mem,
-    opts       => $jvm,
-    require    => Package['storm-mesos'],
+    start       => 'yes',
+    config_file => $config_file,
+    enable      => $enable,
+    jvm_memory  => $mem,
+    opts        => $jvm,
+    require     => Package['storm-mesos'],
   }
 
 }

--- a/manifests/nimbus.pp
+++ b/manifests/nimbus.pp
@@ -23,6 +23,7 @@ class storm::nimbus(
   $inbox_jar_expiration_secs = 3600,
   $task_launch_secs          = 120,
   $reassign                  = true,
+  $enable_service            = true,
   $file_copy_expiration_secs = 600,
   $jvm                       = [
     '-Dlog4j.configuration=file:/etc/storm/storm.log.properties',
@@ -37,12 +38,14 @@ class storm::nimbus(
   }
 
   # Install nimbus /etc/default
-  storm::service { 'nimbus':
-    start      => 'yes',
-    enable     => true,
-    jvm_memory => $mem,
-    opts       => $jvm,
-    require    => Class['storm::config']
+  if $enable_service {
+    storm::service { 'nimbus':
+      start      => 'yes',
+      enable     => true,
+      jvm_memory => $mem,
+      opts       => $jvm,
+      require    => Class['storm::config']
+    }
   }
 
 }

--- a/manifests/nimbus.pp
+++ b/manifests/nimbus.pp
@@ -40,11 +40,12 @@ class storm::nimbus(
   # Install nimbus /etc/default
   if $enable_service {
     storm::service { 'nimbus':
-      start      => 'yes',
-      enable     => true,
-      jvm_memory => $mem,
-      opts       => $jvm,
-      require    => Class['storm::config']
+      start       => 'yes',
+      config_file => $config_file,
+      enable      => true,
+      jvm_memory  => $mem,
+      opts        => $jvm,
+      require     => Class['storm::config']
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,10 +15,11 @@
 #               }
 #
 define storm::service(
-  $start      = 'no',
-  $enable     = false,
-  $jvm_memory = '768m',
-  $opts       = []
+  $start       = 'no',
+  $config_file = '/etc/storm/storm.yaml',
+  $enable      = false,
+  $jvm_memory  = '768m',
+  $opts        = []
   ) {
 
   file { "/etc/default/storm-${name}":
@@ -34,7 +35,7 @@ define storm::service(
       ensure    => 'running',
       hasstatus => true,
       enable    => $enable,
-      subscribe => [ File["/etc/storm/storm.yaml"],
+      subscribe => [ File[$config_file],
                      File["/etc/default/storm"],
                      File["/etc/default/storm-${name}"]
       ],

--- a/manifests/supervisor.pp
+++ b/manifests/supervisor.pp
@@ -39,10 +39,11 @@ class storm::supervisor(
 
   # Install supervisor /etc/default
   storm::service { 'supervisor':
-    start      => 'yes',
-    enable     => $enable,
-    jvm_memory => $mem,
-    opts       => $jvm,
+    start       => 'yes',
+    config_file => $config_file,
+    enable      => $enable,
+    jvm_memory  => $mem,
+    opts        => $jvm,
   }
 
 }

--- a/manifests/ui.pp
+++ b/manifests/ui.pp
@@ -34,10 +34,11 @@ class storm::ui(
 
   # Install ui /etc/default
   storm::service { 'ui':
-    start      => 'yes',
-    enable     => $enable,
-    jvm_memory => $mem,
-    opts       => $jvm,
+    start       => 'yes',
+    config_file => $config_file,
+    enable      => $enable,
+    jvm_memory  => $mem,
+    opts        => $jvm,
   }
 
 }


### PR DESCRIPTION
When running storm in a clustered environment, the workers need the nimbus section in the config file, but not the nimbus service running. This fork requests a change to add an 'enable_service' flag to the nimbus.pp class.