### PR TITLE
Fix defaults enable

### DIFF
--- a/templates/default-service.erb
+++ b/templates/default-service.erb
@@ -1,7 +1,11 @@
 # /etc/default/storm-<%= @name %>
 
 #_ START? _#
-ENABLE="<%= @manage_service %>"
+<% if @manage_service == true %>
+ENABLED="1"
+<% if @manage_service.nil? or @manage_service == false %>
+ENABLED="0"
+<% end -%>
 
 #_ PID FILE _#
 STORM_<%= @name.upcase %>_PID="/var/run/storm-<%= @name %>.pid"

--- a/templates/default-service.erb
+++ b/templates/default-service.erb
@@ -3,8 +3,7 @@
 #_ START? _#
 <% if @manage_service == true %>
 ENABLED="1"
-<% end -%>
-<% if @manage_service.nil? or @manage_service == false %>
+<% else -%>
 ENABLED="0"
 <% end -%>
 

--- a/templates/default-service.erb
+++ b/templates/default-service.erb
@@ -1,7 +1,7 @@
 # /etc/default/storm-<%= @name %>
 
 #_ START? _#
-ENABLE="<%= @start %>"
+ENABLE="<%= @manage_service %>"
 
 #_ PID FILE _#
 STORM_<%= @name.upcase %>_PID="/var/run/storm-<%= @name %>.pid"

--- a/templates/default-service.erb
+++ b/templates/default-service.erb
@@ -3,6 +3,7 @@
 #_ START? _#
 <% if @manage_service == true %>
 ENABLED="1"
+<% end -%>
 <% if @manage_service.nil? or @manage_service == false %>
 ENABLED="0"
 <% end -%>


### PR DESCRIPTION
This branch allows to use ENABLED variable in the same way other Debian daemons do to disable a service.

We use it with https://github.com/serverdensity/storm-debian-packaging

The storm-debian-packaging referenced on this puppet-storm repository is not using ENABLED or ENABLE.