### PR TITLE
Require storm package installation before we try to generate the configu...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,9 +83,10 @@ class storm(
   }
 
   concat { $config_file:
-    owner => $user,
-    group => $group,
-    mode  => '0644',
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    require => Class['storm::install'],
   }
 
   concat::fragment { 'core':


### PR DESCRIPTION
...ration file

We had to add this to prevent that puppet generate the configuration file before having the apache storm package installed.