### PR TITLE
Update for puppet 3.8.5 -- remove redundant parm

### DIFF
--- a/manifests/supervisor.pp
+++ b/manifests/supervisor.pp
@@ -22,7 +22,6 @@ class storm::supervisor(
   $worker_timeout_secs       = 30,
   $monitor_frequency_secs    = 3,
   $heartbeat_frequency_secs  = 5,
-  $enable                    = true,
   $jvm                       = [
     '-Dlog4j.configuration=file:/etc/storm/storm.log.properties',
     '-Dlogfile.name=supervisor.log'


### PR DESCRIPTION
Puppet 3.8.5 isn't happy with redundant $enable parm in supervisor.pp.