### PR TITLE
additions to manage /etc/storm

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class storm(
   validate_array($topology_kryo_register)
 
   class {'storm::install':
+    conf     => $conf,
     ensure   => $packages_ensure,
     packages => $packages,
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,8 +14,13 @@
 class storm::install(
   $packages = ['storm'],
   $ensure   = 'latest',
+  $conf     = '/etc/storm',
 ) {
 
   ensure_resource('package', $packages, {'ensure' => $ensure })
 
+  file { $conf:
+    ensure => 'directory',
+    mode   => '0750',
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -45,10 +45,18 @@ define storm::service(
 
   if $manage_service {
     # workaround for redhat's storm-service rpm 
-    if $facts['os']['family'] == 'redhat' {
-      file { "/etc/init.d/storm-${name}":
-        mode => 'a+x',
+    case $::osfamily {
+      'RedHat': {
+         case $::operatingsystemmajrelease {
+            '6': { 
+               file { "/etc/init.d/storm-${name}":
+                 mode => 'a+x',
+               }
+            }
+            default: {}
+         }
       }
+      default: {}
     }
 
     service { "storm-${name}":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -45,8 +45,10 @@ define storm::service(
 
   if $manage_service {
     # workaround for redhat's storm-service rpm 
-    file { "/etc/init.d/storm-${name}":
-      mode => 'a+x',
+    if $facts['os']['family'] == 'redhat' {
+      file { "/etc/init.d/storm-${name}":
+        mode => 'a+x',
+      }
     }
 
     service { "storm-${name}":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -44,6 +44,11 @@ define storm::service(
   }
 
   if $manage_service {
+    # workaround for redhat's storm-service rpm 
+    file { "/etc/init.d/storm-${name}":
+      mode => 'a+x',
+    }
+
     service { "storm-${name}":
       ensure     => $ensure_service,
       hasstatus  => true,


### PR DESCRIPTION
I tested this on centos and redhat and the module fails due to /etc/storm not existing, so the module cannot expand the template. I feel if the module wants to plunk a template down it should ensure the directory exists first. 