### PR TITLE
templates need better newline fencing

### DIFF
--- a/templates/storm_core.erb
+++ b/templates/storm_core.erb
@@ -1,3 +1,4 @@
+
 #_ STORM CONFIGURATION _#
 #_ MANAGED BY PUPPET - DO NOT EDIT _#
 
@@ -97,3 +98,4 @@ topology.disruptor.wait.timeout.millis: 1000
 topology.metrics.consumer.register:
   - class: "backtype.storm.metric.LoggingMetricsConsumer"
     parallelism.hint: 1
+

--- a/templates/storm_drpc.erb
+++ b/templates/storm_drpc.erb
@@ -24,3 +24,4 @@ drpc.authorizer.acl.strict: false
 transactional.zookeeper.root: "<%= @transactional_zookeeper_root %>"
 transactional.zookeeper.servers: <%= @transactional_zookeeper_servers %>
 transactional.zookeeper.port: <%= @transactional_zookeeper_port %>
+

--- a/templates/storm_logviewer.erb
+++ b/templates/storm_logviewer.erb
@@ -1,5 +1,7 @@
+
 #_ LOGVIEWER _#
 logviewer.port: <%= @port %>
 logviewer.childopts: <%= @childopts %>
 logviewer.cleanup.age.mins: 10080
 logviewer.appender.name: "A1"
+

--- a/templates/storm_mesos.erb
+++ b/templates/storm_mesos.erb
@@ -6,3 +6,4 @@ mesos.executor.uri: "<%= @executor_uri %>"
 <% end -%>
 mesos.framework.role: "<%= @framework_role %>"
 mesos.framework.checkpoint: <%= @framework_checkpoint %>
+

--- a/templates/storm_nimbus.erb
+++ b/templates/storm_nimbus.erb
@@ -18,3 +18,4 @@ nimbus.credential.renewers.freq.secs: 600
 storm.nimbus.retry.times: <%= @retry_times %>
 storm.nimbus.retry.interval.millis: <%= @retry_interval_millis %>
 storm.nimbus.retry.intervalceiling.millis: <%= @retry_intervalceiling_millis %>
+

--- a/templates/storm_supervisor.erb
+++ b/templates/storm_supervisor.erb
@@ -12,3 +12,4 @@ supervisor.enable: <%= @enable %>
 supervisor.worker.shutdown.sleep.secs: 1
 supervisor.supervisors: []
 supervisor.supervisors.commands: []
+

--- a/templates/storm_ui.erb
+++ b/templates/storm_ui.erb
@@ -9,3 +9,4 @@ ui.filter.params: null
 ui.users: null
 ui.header.buffer.bytes: 4096
 ui.http.creds.plugin: backtype.storm.security.auth.DefaultHttpCredentialsPlugin
+


### PR DESCRIPTION
Templates need to have slightly better whitespacing. Demonstrate this with `include ::storm::drpc` without `transactional_zookeeper_port` being set. The null will eat the whitespace and cause the header for the next line to be set without a carriage return. 